### PR TITLE
feat: 이미지 업로드 S3 적용, 회원차단, 최근 사용한 비밀번호 사용불가 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // s3 dependency
+    implementation "com.amazonaws:aws-java-sdk-s3:1.12.281"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/webtoonzoa/controller/UserController.java
+++ b/src/main/java/com/project/webtoonzoa/controller/UserController.java
@@ -12,6 +12,7 @@ import com.project.webtoonzoa.global.util.UserDetailsImpl;
 import com.project.webtoonzoa.service.UserService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -26,7 +27,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,9 +39,10 @@ public class UserController {
 
     @PostMapping("/users/signup")
     public ResponseEntity<CommonResponse<?>> createUser(
-        @Valid @RequestBody SignUpRequestDto userRequestDto,
+        @Valid @RequestPart SignUpRequestDto userRequestDto,
+        @RequestPart(required = false) MultipartFile imageFile,
         BindingResult bindingResult
-    ) {
+    ) throws IOException {
         if (bindingResult.hasErrors()) {
             return validateRequestDto(
                 bindingResult,
@@ -49,7 +53,7 @@ public class UserController {
             CommonResponse.<Long>builder()
                 .status(HttpStatus.CREATED.value())
                 .message("회원가입이 성공하였습니다.")
-                .data(userService.createUser(userRequestDto))
+                .data(userService.createUser(userRequestDto,imageFile))
                 .build()
         );
     }
@@ -124,7 +128,7 @@ public class UserController {
     ){
         return ResponseEntity.status(HttpStatus.OK.value()).body(
             CommonResponse.<List<UserResponseDto>>builder()
-                .message("회원이 조회되었습니다.")
+                .message("회원목록이 조회되었습니다.")
                 .status(HttpStatus.OK.value())
                 .data(userService.getUsers(userDetails.getUser()))
                 .build()

--- a/src/main/java/com/project/webtoonzoa/controller/UserController.java
+++ b/src/main/java/com/project/webtoonzoa/controller/UserController.java
@@ -15,7 +15,6 @@ import jakarta.validation.Valid;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -39,10 +38,11 @@ public class UserController {
 
     @PostMapping("/users/signup")
     public ResponseEntity<CommonResponse<?>> createUser(
-        @Valid @RequestPart SignUpRequestDto userRequestDto,
-        @RequestPart(required = false) MultipartFile imageFile,
-        BindingResult bindingResult
+        @Valid @RequestPart("userRequestDto") SignUpRequestDto userRequestDto,
+        BindingResult bindingResult,
+        @RequestPart(value = "file", required = false) MultipartFile imageFile
     ) throws IOException {
+        System.out.println(bindingResult);
         if (bindingResult.hasErrors()) {
             return validateRequestDto(
                 bindingResult,
@@ -53,7 +53,7 @@ public class UserController {
             CommonResponse.<Long>builder()
                 .status(HttpStatus.CREATED.value())
                 .message("회원가입이 성공하였습니다.")
-                .data(userService.createUser(userRequestDto,imageFile))
+                .data(userService.createUser(userRequestDto, imageFile))
                 .build()
         );
     }
@@ -125,7 +125,7 @@ public class UserController {
     @GetMapping("/users")
     public ResponseEntity<CommonResponse<List<UserResponseDto>>> getUser(
         @AuthenticationPrincipal UserDetailsImpl userDetails
-    ){
+    ) {
         return ResponseEntity.status(HttpStatus.OK.value()).body(
             CommonResponse.<List<UserResponseDto>>builder()
                 .message("회원목록이 조회되었습니다.")

--- a/src/main/java/com/project/webtoonzoa/controller/UserController.java
+++ b/src/main/java/com/project/webtoonzoa/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.project.webtoonzoa.controller;
 
 import com.project.webtoonzoa.dto.user.SignUpRequestDto;
+import com.project.webtoonzoa.dto.user.UserBannedResponseDto;
 import com.project.webtoonzoa.dto.user.UserInfoRequestDto;
 import com.project.webtoonzoa.dto.user.UserInfoResponseDto;
 import com.project.webtoonzoa.dto.user.UserPasswordRequestDto;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -74,6 +76,26 @@ public class UserController {
             .message("로그아웃 되었습니다.")
             .status(HttpStatus.OK.value())
             .build()
+        );
+    }
+
+    @PutMapping("/users/{userId}/bans")
+    public ResponseEntity<CommonResponse<UserBannedResponseDto>> banUser(
+        @PathVariable Long userId,
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        UserBannedResponseDto userBannedResponseDto = userService.banUser(userId,
+            userDetails.getUser());
+        return ResponseEntity.status(HttpStatus.OK.value()).body(
+            CommonResponse.<UserBannedResponseDto>builder()
+                .message(
+                    userBannedResponseDto.isBanned() ?
+                        "회원이 차단되었습니다."
+                        : "회원의 차단이 풀렸습니다"
+                )
+                .status(HttpStatus.OK.value())
+                .data(userBannedResponseDto)
+                .build()
         );
     }
 

--- a/src/main/java/com/project/webtoonzoa/controller/UserController.java
+++ b/src/main/java/com/project/webtoonzoa/controller/UserController.java
@@ -19,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -94,13 +93,11 @@ public class UserController {
         );
     }
 
-
-
     private ResponseEntity<CommonResponse<?>> validateRequestDto(
         BindingResult bindingResult,
         String message
     ) {
-        if(bindingResult.hasErrors()){
+        if (bindingResult.hasErrors()) {
             List<FieldError> fieldErrors = bindingResult.getFieldErrors();
             List<ErrorResponse> ErrorResponseList = new ArrayList<>();
             for (FieldError fieldError : fieldErrors) {
@@ -120,9 +117,10 @@ public class UserController {
 
     @PostMapping("/users/logout")
     public ResponseEntity<CommonResponse<Long>> logoutUser(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
         HttpServletResponse response
     ) {
-        userService.logoutUser(response);
+        userService.logoutUser(response, userDetails.getUser());
         return ResponseEntity.status(HttpStatus.OK.value()).body(CommonResponse.<Long>builder()
             .message("로그아웃 되었습니다.")
             .status(HttpStatus.OK.value())

--- a/src/main/java/com/project/webtoonzoa/controller/UserController.java
+++ b/src/main/java/com/project/webtoonzoa/controller/UserController.java
@@ -5,6 +5,7 @@ import com.project.webtoonzoa.dto.user.UserBannedResponseDto;
 import com.project.webtoonzoa.dto.user.UserInfoRequestDto;
 import com.project.webtoonzoa.dto.user.UserInfoResponseDto;
 import com.project.webtoonzoa.dto.user.UserPasswordRequestDto;
+import com.project.webtoonzoa.dto.user.UserResponseDto;
 import com.project.webtoonzoa.global.response.CommonResponse;
 import com.project.webtoonzoa.global.response.ErrorResponse;
 import com.project.webtoonzoa.global.util.UserDetailsImpl;
@@ -13,12 +14,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -113,6 +116,19 @@ public class UserController {
             );
         }
         return null;
+    }
+
+    @GetMapping("/users")
+    public ResponseEntity<CommonResponse<List<UserResponseDto>>> getUser(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ){
+        return ResponseEntity.status(HttpStatus.OK.value()).body(
+            CommonResponse.<List<UserResponseDto>>builder()
+                .message("회원이 조회되었습니다.")
+                .status(HttpStatus.OK.value())
+                .data(userService.getUsers(userDetails.getUser()))
+                .build()
+        );
     }
 
     @PostMapping("/users/logout")

--- a/src/main/java/com/project/webtoonzoa/dto/user/LoginRequestDto.java
+++ b/src/main/java/com/project/webtoonzoa/dto/user/LoginRequestDto.java
@@ -1,0 +1,13 @@
+package com.project.webtoonzoa.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequestDto {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/project/webtoonzoa/dto/user/LoginRequestDto.java
+++ b/src/main/java/com/project/webtoonzoa/dto/user/LoginRequestDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LoginRequestDto {
+
     private String email;
     private String password;
 }

--- a/src/main/java/com/project/webtoonzoa/dto/user/UserBannedResponseDto.java
+++ b/src/main/java/com/project/webtoonzoa/dto/user/UserBannedResponseDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserBannedResponseDto {
+
     private Long id;
     private boolean banned;
 }

--- a/src/main/java/com/project/webtoonzoa/dto/user/UserBannedResponseDto.java
+++ b/src/main/java/com/project/webtoonzoa/dto/user/UserBannedResponseDto.java
@@ -1,0 +1,13 @@
+package com.project.webtoonzoa.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserBannedResponseDto {
+    private Long id;
+    private boolean banned;
+}

--- a/src/main/java/com/project/webtoonzoa/dto/user/UserInfoRequestDto.java
+++ b/src/main/java/com/project/webtoonzoa/dto/user/UserInfoRequestDto.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 public class UserInfoRequestDto {
 
-    @NotNull
+    @NotNull(message = "nickname이 Null입니다.")
     private String nickname;
 }

--- a/src/main/java/com/project/webtoonzoa/dto/user/UserRequestDto.java
+++ b/src/main/java/com/project/webtoonzoa/dto/user/UserRequestDto.java
@@ -18,5 +18,7 @@ public class UserRequestDto {
     @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$", message = "비밀번호는 8글자~20자, 대문자 1개, 소문자 1개, 숫자 1개, 특수문자 1개 이상 포함하세요.")
     private String password;
 
+    private String imagePath;
+
     private String adminToken;
 }

--- a/src/main/java/com/project/webtoonzoa/dto/user/UserResponseDto.java
+++ b/src/main/java/com/project/webtoonzoa/dto/user/UserResponseDto.java
@@ -1,5 +1,30 @@
 package com.project.webtoonzoa.dto.user;
 
+import com.project.webtoonzoa.entity.Enum.UserRoleEnum;
+import com.project.webtoonzoa.entity.User;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
 public class UserResponseDto {
 
+    private Long id;
+    private String email;
+    private String nickname;
+    private UserRoleEnum role;
+    private boolean banned;
+    private String imagePath;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public UserResponseDto(User user) {
+        this.id = user.getId();
+        this.email = user.getEmail();
+        this.nickname = user.getNickname();
+        this.role = user.getRole();
+        this.banned = user.isBanned();
+        this.imagePath = user.getImagePath();
+        this.createdAt = user.getCreatedAt();
+        this.modifiedAt = user.getModifiedAt();
+    }
 }

--- a/src/main/java/com/project/webtoonzoa/entity/RefreshToken.java
+++ b/src/main/java/com/project/webtoonzoa/entity/RefreshToken.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class RefreshToken {
+public class RefreshToken extends TimeStampedByCreatedAt {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/project/webtoonzoa/entity/RefreshToken.java
+++ b/src/main/java/com/project/webtoonzoa/entity/RefreshToken.java
@@ -1,6 +1,5 @@
 package com.project.webtoonzoa.entity;
 
-import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -28,7 +27,7 @@ public class RefreshToken extends TimeStampedByCreatedAt {
     @Column(nullable = false)
     private String refreshToken;
 
-    public RefreshToken(User user, String refreshToken){
+    public RefreshToken(User user, String refreshToken) {
         this.user = user;
         this.refreshToken = refreshToken;
     }

--- a/src/main/java/com/project/webtoonzoa/entity/RefreshToken.java
+++ b/src/main/java/com/project/webtoonzoa/entity/RefreshToken.java
@@ -1,0 +1,35 @@
+package com.project.webtoonzoa.entity;
+
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Column(nullable = false)
+    private String refreshToken;
+
+    public RefreshToken(User user, String refreshToken){
+        this.user = user;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/project/webtoonzoa/entity/TimeStampedByCreatedAt.java
+++ b/src/main/java/com/project/webtoonzoa/entity/TimeStampedByCreatedAt.java
@@ -1,0 +1,19 @@
+package com.project.webtoonzoa.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class TimeStampedByCreatedAt {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/project/webtoonzoa/entity/User.java
+++ b/src/main/java/com/project/webtoonzoa/entity/User.java
@@ -39,6 +39,12 @@ public class User extends TimeStamped {
 
     private boolean banned;
 
+    private String imagePath;
+
+    public void updateImagePath(String imagePath){
+        this.imagePath = imagePath;
+    }
+
     public void updateBanned() {
         this.banned = !banned;
     }

--- a/src/main/java/com/project/webtoonzoa/entity/User.java
+++ b/src/main/java/com/project/webtoonzoa/entity/User.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,6 +38,12 @@ public class User extends TimeStamped {
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private UserRoleEnum role;
+
+    private boolean banned;
+
+    public void updateBanned(){
+        this.banned = !banned;
+    }
 
     public void updatedNickname(String nickname) {
         this.nickname = nickname;

--- a/src/main/java/com/project/webtoonzoa/entity/User.java
+++ b/src/main/java/com/project/webtoonzoa/entity/User.java
@@ -8,8 +8,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,7 +39,7 @@ public class User extends TimeStamped {
 
     private boolean banned;
 
-    public void updateBanned(){
+    public void updateBanned() {
         this.banned = !banned;
     }
 

--- a/src/main/java/com/project/webtoonzoa/entity/User.java
+++ b/src/main/java/com/project/webtoonzoa/entity/User.java
@@ -41,7 +41,7 @@ public class User extends TimeStamped {
 
     private String imagePath;
 
-    public void updateImagePath(String imagePath){
+    public void updateImagePath(String imagePath) {
         this.imagePath = imagePath;
     }
 

--- a/src/main/java/com/project/webtoonzoa/entity/UserRecentPassword.java
+++ b/src/main/java/com/project/webtoonzoa/entity/UserRecentPassword.java
@@ -1,0 +1,35 @@
+package com.project.webtoonzoa.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class UserRecentPassword extends TimeStampedByCreatedAt {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Column(nullable = false)
+    private String password;
+
+    public void savePassword(String password) {
+        this.password = password;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+}

--- a/src/main/java/com/project/webtoonzoa/global/config/S3Config.java
+++ b/src/main/java/com/project/webtoonzoa/global/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.project.webtoonzoa.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.s3.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.s3.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client(){
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+            .standard()
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .withRegion(region)
+            .build();
+    }
+}

--- a/src/main/java/com/project/webtoonzoa/global/config/S3Config.java
+++ b/src/main/java/com/project/webtoonzoa/global/config/S3Config.java
@@ -4,7 +4,6 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class S3Config {
+
     @Value("${cloud.aws.s3.credentials.accessKey}")
     private String accessKey;
 
@@ -22,7 +22,7 @@ public class S3Config {
     private String region;
 
     @Bean
-    public AmazonS3 amazonS3Client(){
+    public AmazonS3 amazonS3Client() {
         AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
 
         return AmazonS3ClientBuilder

--- a/src/main/java/com/project/webtoonzoa/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/webtoonzoa/global/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import com.project.webtoonzoa.global.filter.JwtAuthenticationFilter;
 import com.project.webtoonzoa.global.filter.JwtAuthorizationFilter;
 import com.project.webtoonzoa.global.util.JwtUtil;
 import com.project.webtoonzoa.global.util.UserDetailsServiceImpl;
+import com.project.webtoonzoa.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,18 +25,13 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity // Spring Security 지원을 가능하게 함
 @EnableGlobalMethodSecurity(securedEnabled = true)
+@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
-
-    public SecurityConfig(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService,
-        AuthenticationConfiguration authenticationConfiguration) {
-        this.jwtUtil = jwtUtil;
-        this.userDetailsService = userDetailsService;
-        this.authenticationConfiguration = authenticationConfiguration;
-    }
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -49,14 +46,14 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, refreshTokenRepository);
         filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
         return filter;
     }
 
     @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() {
-        return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService, refreshTokenRepository);
     }
 
     @Bean

--- a/src/main/java/com/project/webtoonzoa/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/webtoonzoa/global/config/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil, refreshTokenRepository);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil,
+            refreshTokenRepository);
         filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
         return filter;
     }

--- a/src/main/java/com/project/webtoonzoa/global/exception/ControllerAdvice.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/ControllerAdvice.java
@@ -25,10 +25,34 @@ public class ControllerAdvice {
         );
     }
 
+    @ExceptionHandler(UserNotExistence.class)
+    public ResponseEntity<CommonResponse<String>> handleValidationException(
+        UserNotExistence e) {
+        log.error("회원 비밀번호 불일치 에러", e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            CommonResponse.<String>builder()
+                .message(e.getMessage())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .build()
+        );
+    }
+
     @ExceptionHandler(PasswordNotConfirmException.class)
     public ResponseEntity<CommonResponse<String>> handleValidationException(
         PasswordNotConfirmException e) {
         log.error("변경 비밀번호 불일치 에러", e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            CommonResponse.<String>builder()
+                .message(e.getMessage())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .build()
+        );
+    }
+
+    @ExceptionHandler(IsNotAdminUser.class)
+    public ResponseEntity<CommonResponse<String>> handleValidationException(
+        IsNotAdminUser e) {
+        log.error("관리자 불일치 에러", e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
             CommonResponse.<String>builder()
                 .message(e.getMessage())

--- a/src/main/java/com/project/webtoonzoa/global/exception/ControllerAdvice.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/ControllerAdvice.java
@@ -1,7 +1,6 @@
 package com.project.webtoonzoa.global.exception;
 
 import com.project.webtoonzoa.global.response.CommonResponse;
-import jakarta.validation.ConstraintViolationException;
 import java.nio.file.AccessDeniedException;
 import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/project/webtoonzoa/global/exception/ControllerAdvice.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/ControllerAdvice.java
@@ -61,6 +61,18 @@ public class ControllerAdvice {
         );
     }
 
+    @ExceptionHandler(EmailExistenceException.class)
+    public ResponseEntity<CommonResponse<String>> handleValidationException(
+        EmailExistenceException e) {
+        log.error("이메일 중복 에러", e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            CommonResponse.<String>builder()
+                .message(e.getMessage())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .build()
+        );
+    }
+
     @ExceptionHandler(IsNotAdminUser.class)
     public ResponseEntity<CommonResponse<String>> handleValidationException(
         IsNotAdminUser e) {

--- a/src/main/java/com/project/webtoonzoa/global/exception/ControllerAdvice.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/ControllerAdvice.java
@@ -49,6 +49,18 @@ public class ControllerAdvice {
         );
     }
 
+    @ExceptionHandler(PasswordIsRecentPasswordException.class)
+    public ResponseEntity<CommonResponse<String>> handleValidationException(
+        PasswordIsRecentPasswordException e) {
+        log.error("최근 사용한 비밀번호 에러", e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            CommonResponse.<String>builder()
+                .message(e.getMessage())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .build()
+        );
+    }
+
     @ExceptionHandler(IsNotAdminUser.class)
     public ResponseEntity<CommonResponse<String>> handleValidationException(
         IsNotAdminUser e) {

--- a/src/main/java/com/project/webtoonzoa/global/exception/ControllerAdvice.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/ControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.project.webtoonzoa.global.exception;
 
 import com.project.webtoonzoa.global.response.CommonResponse;
+import jakarta.validation.ConstraintViolationException;
 import java.nio.file.AccessDeniedException;
 import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
@@ -28,7 +29,7 @@ public class ControllerAdvice {
     @ExceptionHandler(UserNotExistence.class)
     public ResponseEntity<CommonResponse<String>> handleValidationException(
         UserNotExistence e) {
-        log.error("회원 비밀번호 불일치 에러", e);
+        log.error("회원 에러", e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
             CommonResponse.<String>builder()
                 .message(e.getMessage())

--- a/src/main/java/com/project/webtoonzoa/global/exception/EmailExistenceException.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/EmailExistenceException.java
@@ -1,0 +1,8 @@
+package com.project.webtoonzoa.global.exception;
+
+public class EmailExistenceException extends IllegalStateException {
+
+    public EmailExistenceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/project/webtoonzoa/global/exception/IsNotAdminUser.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/IsNotAdminUser.java
@@ -1,0 +1,8 @@
+package com.project.webtoonzoa.global.exception;
+
+public class IsNotAdminUser extends IllegalStateException {
+
+    public IsNotAdminUser(String message) {
+
+    }
+}

--- a/src/main/java/com/project/webtoonzoa/global/exception/IsNotAdminUser.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/IsNotAdminUser.java
@@ -3,6 +3,6 @@ package com.project.webtoonzoa.global.exception;
 public class IsNotAdminUser extends IllegalStateException {
 
     public IsNotAdminUser(String message) {
-
+        super(message);
     }
 }

--- a/src/main/java/com/project/webtoonzoa/global/exception/PasswordIsRecentPasswordException.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/PasswordIsRecentPasswordException.java
@@ -1,6 +1,7 @@
 package com.project.webtoonzoa.global.exception;
 
 public class PasswordIsRecentPasswordException extends IllegalStateException {
+
     public PasswordIsRecentPasswordException(String message) {
         super(message);
     }

--- a/src/main/java/com/project/webtoonzoa/global/exception/PasswordIsRecentPasswordException.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/PasswordIsRecentPasswordException.java
@@ -1,0 +1,8 @@
+package com.project.webtoonzoa.global.exception;
+
+public class PasswordIsRecentPasswordException extends IllegalStateException {
+
+    public PasswordIsRecentPasswordException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/project/webtoonzoa/global/exception/PasswordIsRecentPasswordException.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/PasswordIsRecentPasswordException.java
@@ -1,7 +1,6 @@
 package com.project.webtoonzoa.global.exception;
 
 public class PasswordIsRecentPasswordException extends IllegalStateException {
-
     public PasswordIsRecentPasswordException(String message) {
         super(message);
     }

--- a/src/main/java/com/project/webtoonzoa/global/exception/UserNotExistence.java
+++ b/src/main/java/com/project/webtoonzoa/global/exception/UserNotExistence.java
@@ -1,0 +1,7 @@
+package com.project.webtoonzoa.global.exception;
+
+public class UserNotExistence extends NullPointerException {
+
+    public UserNotExistence(String message) {
+    }
+}

--- a/src/main/java/com/project/webtoonzoa/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/webtoonzoa/global/filter/JwtAuthenticationFilter.java
@@ -92,10 +92,11 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     private boolean validateRefreshToken(HttpServletResponse response, UserDetailsImpl user)
         throws IOException {
         if (refreshTokenRepository.findByUserId(user.getUser().getId()) != null) {
-            String jsonResponse = new ObjectMapper().writeValueAsString(CommonResponse.<Void>builder()
-                .message("이미 로그인이 되어있어 refresh token이 존재하는 상태입니다. Access token을 사용하여 진행해주세요!")
-                .status(HttpStatus.BAD_REQUEST.value())
-                .build()
+            String jsonResponse = new ObjectMapper().writeValueAsString(
+                CommonResponse.<Void>builder()
+                    .message("이미 로그인이 되어있어 refresh token이 존재하는 상태입니다. Access token을 사용하여 진행해주세요!")
+                    .status(HttpStatus.BAD_REQUEST.value())
+                    .build()
             );
 
             response.setStatus(HttpStatus.BAD_REQUEST.value());

--- a/src/main/java/com/project/webtoonzoa/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/webtoonzoa/global/filter/JwtAuthenticationFilter.java
@@ -1,11 +1,13 @@
 package com.project.webtoonzoa.global.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.project.webtoonzoa.dto.user.SignUpRequestDto;
+import com.project.webtoonzoa.dto.user.LoginRequestDto;
 import com.project.webtoonzoa.entity.Enum.UserRoleEnum;
+import com.project.webtoonzoa.entity.RefreshToken;
 import com.project.webtoonzoa.global.response.CommonResponse;
 import com.project.webtoonzoa.global.util.JwtUtil;
 import com.project.webtoonzoa.global.util.UserDetailsImpl;
+import com.project.webtoonzoa.repository.RefreshTokenRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,9 +25,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
     private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
 
-    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, RefreshTokenRepository refreshTokenRepository) {
         this.jwtUtil = jwtUtil;
+        this.refreshTokenRepository = refreshTokenRepository;
         setFilterProcessesUrl("/users/login");
     }
 
@@ -34,8 +38,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         HttpServletResponse response) throws AuthenticationException {
         log.info("로그인 시도");
         try {
-            SignUpRequestDto requestDto = new ObjectMapper().readValue(request.getInputStream(),
-                SignUpRequestDto.class);
+            LoginRequestDto requestDto = new ObjectMapper().readValue(request.getInputStream(),
+                LoginRequestDto.class);
 
             return getAuthenticationManager().authenticate(
                 new UsernamePasswordAuthenticationToken(
@@ -59,12 +63,20 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String username = user.getUsername();
         UserRoleEnum role = user.getUser().getRole();
 
-        String token = jwtUtil.createToken(username, role);
-        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, token);
+        String accessToken = jwtUtil.createAccessToken(username, role);
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, accessToken);
+
+        if (validateRefreshToken(response, user)) {
+            return;
+        }
+
+        String refreshToken = jwtUtil.createRefreshToken(username, role).substring(7);
+
+        RefreshToken refreshTokenObj = new RefreshToken(user.getUser(), refreshToken);
+        refreshTokenRepository.save(refreshTokenObj);
 
         // JSON으로 변환
-        ObjectMapper objectMapper = new ObjectMapper();
-        String jsonResponse = objectMapper.writeValueAsString(CommonResponse.<Void>builder()
+        String jsonResponse = new ObjectMapper().writeValueAsString(CommonResponse.<Void>builder()
             .message("로그인에 성공하였습니다.")
             .status(HttpStatus.OK.value())
             .build()
@@ -77,6 +89,25 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         response.getWriter().flush();
     }
 
+    private boolean validateRefreshToken(HttpServletResponse response, UserDetailsImpl user)
+        throws IOException {
+        if (refreshTokenRepository.findByUserId(user.getUser().getId()) != null) {
+            String jsonResponse = new ObjectMapper().writeValueAsString(CommonResponse.<Void>builder()
+                .message("이미 로그인이 되어있어 refresh token이 존재하는 상태입니다. Access token을 사용하여 진행해주세요!")
+                .status(HttpStatus.BAD_REQUEST.value())
+                .build()
+            );
+
+            response.setStatus(HttpStatus.BAD_REQUEST.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write(jsonResponse);
+            response.getWriter().flush();
+            return true;
+        }
+        return false;
+    }
+
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request,
         HttpServletResponse response, AuthenticationException failed)
@@ -85,12 +116,12 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
         ObjectMapper objectMapper = new ObjectMapper();
         String jsonResponse = objectMapper.writeValueAsString(CommonResponse.<Void>builder()
-            .message("존재하지 않는 회원입니다.")
-            .status(HttpStatus.BAD_REQUEST.value())
+            .message("이메일이나 비밀번호가 틀렸습니다.")
+            .status(HttpStatus.UNAUTHORIZED.value())
             .build()
         );
 
-        response.setStatus(HttpStatus.BAD_REQUEST.value());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(jsonResponse);

--- a/src/main/java/com/project/webtoonzoa/global/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/webtoonzoa/global/filter/JwtAuthorizationFilter.java
@@ -1,7 +1,13 @@
 package com.project.webtoonzoa.global.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.webtoonzoa.entity.RefreshToken;
+import com.project.webtoonzoa.entity.User;
+import com.project.webtoonzoa.global.response.CommonResponse;
 import com.project.webtoonzoa.global.util.JwtUtil;
+import com.project.webtoonzoa.global.util.UserDetailsImpl;
 import com.project.webtoonzoa.global.util.UserDetailsServiceImpl;
+import com.project.webtoonzoa.repository.RefreshTokenRepository;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -10,6 +16,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -23,10 +30,12 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
+    private final RefreshTokenRepository refreshTokenRepository;
 
-    public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+    public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService, RefreshTokenRepository refreshTokenRepository) {
         this.jwtUtil = jwtUtil;
         this.userDetailsService = userDetailsService;
+        this.refreshTokenRepository = refreshTokenRepository;
     }
 
     @Override
@@ -36,20 +45,56 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         String tokenValue = jwtUtil.getJwtFromHeader(req);
 
         if (StringUtils.hasText(tokenValue)) {
-            // JWT 토큰 substring
+            int tokenStatus =  jwtUtil.validateToken(tokenValue);
+            // 0 이면 정상적인 토큰
+            // 1 이면 기간만 만료된 토큰
+            // 2 이면 비장상적인 토큰
+            if (tokenStatus == 1) {
+                try{
+                    Claims info = jwtUtil.getUserInfoFromExpiredToken(tokenValue);
+                    UserDetailsImpl userDetails = (UserDetailsImpl) userDetailsService.loadUserByUsername(info.getSubject());
+                    User user = userDetails.getUser();
+                    RefreshToken refreshToken = refreshTokenRepository.findByUserId(userDetails.getUser().getId());
+                    if (refreshToken != null && jwtUtil.validateToken(refreshToken.getRefreshToken()) == 0){
+                        String newAccessToken = jwtUtil.createAccessToken(user.getEmail(), user.getRole());
+                        res.addHeader(JwtUtil.AUTHORIZATION_HEADER,newAccessToken);
+                    }else{
+                        res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-            if (!jwtUtil.validateToken(tokenValue)) {
-                res.getWriter().write("Token is invalid");
+                        String jsonResponse = new ObjectMapper().writeValueAsString(
+                            CommonResponse.<Void>builder()
+                                .message("Access Token과 Refresh Token이 모두 만료되었습니다.").build());
+
+                        res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                        res.setCharacterEncoding("UTF-8");
+                        res.getWriter().write(jsonResponse);
+                        refreshTokenRepository.delete(refreshToken);
+                        return;
+                    }
+                }catch(Exception e){
+                    logger.error(e.getMessage());
+                    logger.error("JWT 인가 오류");
+                    return;
+                }
+            }
+            else if(tokenStatus == 2){
+                String jsonResponse = new ObjectMapper().writeValueAsString(CommonResponse.<Void>builder()
+                    .message("검증 되지 않은 토큰이거나 토큰이 존재 하지 않습니다.")
+                    .status(HttpStatus.BAD_REQUEST.value())
+                    .build()
+                );
+                res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                res.setCharacterEncoding("UTF-8");
                 res.setStatus(HttpStatus.BAD_REQUEST.value());
+                res.getWriter().write(jsonResponse);
                 log.error("Token Error");
                 return;
             }
-
             Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
             try {
                 setAuthentication(info.getSubject());
             } catch (Exception e) {
-                log.error(e.getMessage());
+                log.error("jwt 인가 부분 에러 : token status RED ERR");
                 return;
             }
         }

--- a/src/main/java/com/project/webtoonzoa/global/response/ErrorResponse.java
+++ b/src/main/java/com/project/webtoonzoa/global/response/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.project.webtoonzoa.global.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ErrorResponse {
+
+    private final String message;
+}

--- a/src/main/java/com/project/webtoonzoa/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/project/webtoonzoa/repository/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package com.project.webtoonzoa.repository;
+
+import com.project.webtoonzoa.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    RefreshToken findByUserId(Long id);
+}

--- a/src/main/java/com/project/webtoonzoa/repository/UserRecentPasswordRepository.java
+++ b/src/main/java/com/project/webtoonzoa/repository/UserRecentPasswordRepository.java
@@ -1,0 +1,10 @@
+package com.project.webtoonzoa.repository;
+
+import com.project.webtoonzoa.entity.UserRecentPassword;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRecentPasswordRepository extends JpaRepository<UserRecentPassword, Long> {
+
+    List<UserRecentPassword> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/project/webtoonzoa/service/ImageService.java
+++ b/src/main/java/com/project/webtoonzoa/service/ImageService.java
@@ -1,15 +1,21 @@
 package com.project.webtoonzoa.service;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class ImageService {
+
+    @Value("${defaultImage.path}")
+    private String defaultImagePath;
+
+    @Value("${upload.path}")
+    private String uploadPath;
 
     private final S3Service s3Service;
 
@@ -20,9 +26,8 @@ public class ImageService {
     private String getImageName(MultipartFile file) throws IOException {
         if (file != null) {
             String originalFileName = UUID.randomUUID() + file.getOriginalFilename();
-            s3Service.upload(file, originalFileName);
-            return originalFileName;
+            return s3Service.upload(file, originalFileName);
         }
-        return "";
+        return defaultImagePath;
     }
 }

--- a/src/main/java/com/project/webtoonzoa/service/ImageService.java
+++ b/src/main/java/com/project/webtoonzoa/service/ImageService.java
@@ -1,0 +1,28 @@
+package com.project.webtoonzoa.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Service s3Service;
+
+    public String createImageName(MultipartFile file) throws IOException {
+        return getImageName(file);
+    }
+
+    private String getImageName(MultipartFile file) throws IOException {
+        if (file != null) {
+            String originalFileName = UUID.randomUUID() + file.getOriginalFilename();
+            s3Service.upload(file, originalFileName);
+            return originalFileName;
+        }
+        return "";
+    }
+}

--- a/src/main/java/com/project/webtoonzoa/service/S3Service.java
+++ b/src/main/java/com/project/webtoonzoa/service/S3Service.java
@@ -12,6 +12,7 @@ import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -19,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Service
 public class S3Service {
+
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
@@ -29,6 +31,7 @@ public class S3Service {
         // 메타데이터 생성
         ObjectMetadata objMeta = new ObjectMetadata();
         objMeta.setContentLength(multipartFile.getInputStream().available());
+        objMeta.setContentType(MediaType.IMAGE_JPEG_VALUE);
         // putObject(버킷명, 파일명, 파일데이터, 메타데이터)로 S3에 객체 등록
         amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
         // 등록된 객체의 url 반환 (decoder: url 안의 한글or특수문자 깨짐 방지)
@@ -36,7 +39,7 @@ public class S3Service {
     }
 
     /* 2. 파일 삭제 */
-    public void delete (String keyName) {
+    public void delete(String keyName) {
         try {
             // deleteObject(버킷명, 키값)으로 객체 삭제
             amazonS3.deleteObject(bucket, keyName);
@@ -46,7 +49,7 @@ public class S3Service {
     }
 
     /* 3. 파일의 preSigned URL 반환 */
-    public String getPreSignedURL (String keyName) {
+    public String getPreSignedURL(String keyName) {
         String preSignedURL = "";
         // preSigned URL이 유효하게 동작할 만료기한 설정 (2분)
         Date expiration = new Date();
@@ -56,7 +59,8 @@ public class S3Service {
 
         try {
             // presigned URL 발급
-            GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, keyName)
+            GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(
+                bucket, keyName)
                 .withMethod(HttpMethod.GET)
                 .withExpiration(expiration);
             URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);

--- a/src/main/java/com/project/webtoonzoa/service/S3Service.java
+++ b/src/main/java/com/project/webtoonzoa/service/S3Service.java
@@ -1,0 +1,70 @@
+package com.project.webtoonzoa.service;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class S3Service {
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+
+    /* 1. 파일 업로드 */
+    public String upload(MultipartFile multipartFile, String s3FileName) throws IOException {
+        // 메타데이터 생성
+        ObjectMetadata objMeta = new ObjectMetadata();
+        objMeta.setContentLength(multipartFile.getInputStream().available());
+        // putObject(버킷명, 파일명, 파일데이터, 메타데이터)로 S3에 객체 등록
+        amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
+        // 등록된 객체의 url 반환 (decoder: url 안의 한글or특수문자 깨짐 방지)
+        return URLDecoder.decode(amazonS3.getUrl(bucket, s3FileName).toString(), "utf-8");
+    }
+
+    /* 2. 파일 삭제 */
+    public void delete (String keyName) {
+        try {
+            // deleteObject(버킷명, 키값)으로 객체 삭제
+            amazonS3.deleteObject(bucket, keyName);
+        } catch (AmazonServiceException e) {
+            log.error(e.toString());
+        }
+    }
+
+    /* 3. 파일의 preSigned URL 반환 */
+    public String getPreSignedURL (String keyName) {
+        String preSignedURL = "";
+        // preSigned URL이 유효하게 동작할 만료기한 설정 (2분)
+        Date expiration = new Date();
+        Long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 2;
+        expiration.setTime(expTimeMillis);
+
+        try {
+            // presigned URL 발급
+            GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, keyName)
+                .withMethod(HttpMethod.GET)
+                .withExpiration(expiration);
+            URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+            preSignedURL = url.toString();
+        } catch (Exception e) {
+            log.error(e.toString());
+        }
+
+        return preSignedURL;
+    }
+}

--- a/src/main/java/com/project/webtoonzoa/service/UserService.java
+++ b/src/main/java/com/project/webtoonzoa/service/UserService.java
@@ -21,9 +21,7 @@ import com.project.webtoonzoa.repository.RefreshTokenRepository;
 import com.project.webtoonzoa.repository.UserRecentPasswordRepository;
 import com.project.webtoonzoa.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.constraints.Email;
 import java.io.IOException;
-import java.sql.Ref;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -163,9 +161,10 @@ public class UserService {
     }
 
     private void validateEmail(String email) {
-        if(userRepository.findByEmail(email).isPresent()){
+        if (userRepository.findByEmail(email).isPresent()) {
             throw new EmailExistenceException("중복된 이메일이 존재합니다!");
-        };
+        }
+        ;
     }
 
     private User getUserById(Long userId) {

--- a/src/main/java/com/project/webtoonzoa/service/UserService.java
+++ b/src/main/java/com/project/webtoonzoa/service/UserService.java
@@ -1,14 +1,18 @@
 package com.project.webtoonzoa.service;
 
 import com.project.webtoonzoa.dto.user.SignUpRequestDto;
+import com.project.webtoonzoa.dto.user.UserBannedResponseDto;
 import com.project.webtoonzoa.dto.user.UserInfoRequestDto;
 import com.project.webtoonzoa.dto.user.UserInfoResponseDto;
 import com.project.webtoonzoa.dto.user.UserPasswordRequestDto;
 import com.project.webtoonzoa.entity.Enum.UserRoleEnum;
 import com.project.webtoonzoa.entity.User;
+import com.project.webtoonzoa.global.exception.IsNotAdminUser;
 import com.project.webtoonzoa.global.exception.PasswordNotConfirmException;
 import com.project.webtoonzoa.global.exception.PasswordNotEqualException;
+import com.project.webtoonzoa.global.exception.UserNotExistence;
 import com.project.webtoonzoa.global.util.JwtUtil;
+import com.project.webtoonzoa.repository.UserRecentPasswordRepository;
 import com.project.webtoonzoa.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +27,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserRecentPasswordRepository userRecentPasswordRepository;
 
     private final String ADMIN_TOKEN = "AAABnvxRVklrnYxKZ0aHgTBcXukeZygoC";
 
@@ -59,18 +64,22 @@ public class UserService {
     @Transactional
     public UserInfoResponseDto updateUser(User user, UserInfoRequestDto requestDto) {
         String nickname = requestDto.getNickname();
-        User savedUser = getUser(user);
+        User savedUser = getUserById(user.getId());
         savedUser.updatedNickname(nickname);
         return new UserInfoResponseDto(user.getId(), nickname);
     }
 
     @Transactional
     public void updatePassword(UserPasswordRequestDto requestDto, User user) {
-        User savedUser = getUser(user);
+        User savedUser = getUserById(user.getId());
         validatePasswordBySavedUser(requestDto, savedUser);
+        validatePasswordByRecentPasswordTop3();
         validateConfirmPassword(requestDto);
         String updatedPassword = passwordEncoder.encode(requestDto.getChangePassword());
         savedUser.updatePassword(updatedPassword);
+    }
+
+    private void validatePasswordByRecentPasswordTop3() {
     }
 
     private void validatePasswordBySavedUser(UserPasswordRequestDto requestDto, User savedUser) {
@@ -85,8 +94,24 @@ public class UserService {
         }
     }
 
-    private User getUser(User user) {
-        return userRepository.findById(user.getId())
-            .orElseThrow(() -> new NullPointerException("존재하지 않는 회원입니다."));
+    @Transactional
+    public UserBannedResponseDto banUser(Long userId, User user) {
+        validateAdmin(user);
+        User savedUser = getUserById(userId);
+        savedUser.updateBanned();
+        Long savedUserId = savedUser.getId();
+        boolean banned = savedUser.isBanned();
+        return new UserBannedResponseDto(savedUserId, banned);
+    }
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new UserNotExistence("존재하지 않는 회원입니다."));
+    }
+
+    private static void validateAdmin(User user) {
+        if(!user.getRole().equals(UserRoleEnum.ADMIN)){
+            throw new IsNotAdminUser("관리자가 아니기에 회원을 밴을 할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/project/webtoonzoa/service/UserService.java
+++ b/src/main/java/com/project/webtoonzoa/service/UserService.java
@@ -6,6 +6,7 @@ import com.project.webtoonzoa.dto.user.UserInfoRequestDto;
 import com.project.webtoonzoa.dto.user.UserInfoResponseDto;
 import com.project.webtoonzoa.dto.user.UserPasswordRequestDto;
 import com.project.webtoonzoa.entity.Enum.UserRoleEnum;
+import com.project.webtoonzoa.entity.RefreshToken;
 import com.project.webtoonzoa.entity.User;
 import com.project.webtoonzoa.entity.UserRecentPassword;
 import com.project.webtoonzoa.global.exception.IsNotAdminUser;
@@ -14,9 +15,11 @@ import com.project.webtoonzoa.global.exception.PasswordNotConfirmException;
 import com.project.webtoonzoa.global.exception.PasswordNotEqualException;
 import com.project.webtoonzoa.global.exception.UserNotExistence;
 import com.project.webtoonzoa.global.util.JwtUtil;
+import com.project.webtoonzoa.repository.RefreshTokenRepository;
 import com.project.webtoonzoa.repository.UserRecentPasswordRepository;
 import com.project.webtoonzoa.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
+import java.sql.Ref;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,6 +34,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final UserRecentPasswordRepository userRecentPasswordRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     private final String ADMIN_TOKEN = "AAABnvxRVklrnYxKZ0aHgTBcXukeZygoC";
 
@@ -61,8 +65,11 @@ public class UserService {
         return role;
     }
 
-    public void logoutUser(HttpServletResponse response) {
+    @Transactional
+    public void logoutUser(HttpServletResponse response, User user) {
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, null);
+        RefreshToken refreshToken = refreshTokenRepository.findByUserId(user.getId());
+        refreshTokenRepository.delete(refreshToken);
     }
 
     @Transactional

--- a/src/main/java/com/project/webtoonzoa/service/UserService.java
+++ b/src/main/java/com/project/webtoonzoa/service/UserService.java
@@ -5,6 +5,7 @@ import com.project.webtoonzoa.dto.user.UserBannedResponseDto;
 import com.project.webtoonzoa.dto.user.UserInfoRequestDto;
 import com.project.webtoonzoa.dto.user.UserInfoResponseDto;
 import com.project.webtoonzoa.dto.user.UserPasswordRequestDto;
+import com.project.webtoonzoa.dto.user.UserResponseDto;
 import com.project.webtoonzoa.entity.Enum.UserRoleEnum;
 import com.project.webtoonzoa.entity.RefreshToken;
 import com.project.webtoonzoa.entity.User;
@@ -160,9 +161,15 @@ public class UserService {
             .orElseThrow(() -> new UserNotExistence("존재하지 않는 회원입니다."));
     }
 
-    private static void validateAdmin(User user) {
+    public List<UserResponseDto> getUsers(User user) {
+        validateAdmin(user);
+        List<User> users = userRepository.findAll();
+        return users.stream().map(UserResponseDto::new).toList();
+    }
+
+    private void validateAdmin(User user) {
         if (!user.getRole().equals(UserRoleEnum.ADMIN)) {
-            throw new IsNotAdminUser("관리자가 아니기에 회원을 밴을 할 수 없습니다.");
+            throw new IsNotAdminUser("관리자가 권한이 없습니다.");
         }
     }
 }

--- a/src/main/java/com/project/webtoonzoa/service/WebtoonService.java
+++ b/src/main/java/com/project/webtoonzoa/service/WebtoonService.java
@@ -68,7 +68,7 @@ public class WebtoonService {
     }
 
     private void checkRole(User user) {
-        if (user.getRole().equals(UserRoleEnum.ADMIN)) {
+        if (!user.getRole().equals(UserRoleEnum.ADMIN)) {
             throw new AccessDeniedException("접근 권한이 없습니다.");
         }
     }

--- a/src/main/resources/application.properties.sample
+++ b/src/main/resources/application.properties.sample
@@ -10,3 +10,5 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
 
 jwt.secret.key=dGhyZWV0aHJlZXRocmVldGhyZWV0aHJlZXRocmVldGhyZWU=
+
+admin.token=AAABnvxRVklrnYxKZ0aHgTBcXukeZygoCasewfsdf

--- a/src/main/resources/application.properties.sample
+++ b/src/main/resources/application.properties.sample
@@ -12,3 +12,12 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 jwt.secret.key=dGhyZWV0aHJlZXRocmVldGhyZWV0aHJlZXRocmVldGhyZWU=
 
 admin.token=AAABnvxRVklrnYxKZ0aHgTBcXukeZygoCasewfsdf
+
+# aws s3 config
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto-=false
+
+# aws s3 key
+cloud.aws.s3.credentials.accessKey={accessKey}
+cloud.aws.s3.credentials.secretKey={secretKey}
+cloud.aws.s3.bucket={bucket-name}

--- a/src/main/resources/application.properties.sample
+++ b/src/main/resources/application.properties.sample
@@ -21,3 +21,6 @@ cloud.aws.stack.auto-=false
 cloud.aws.s3.credentials.accessKey={accessKey}
 cloud.aws.s3.credentials.secretKey={secretKey}
 cloud.aws.s3.bucket={bucket-name}
+
+# default image path
+defaultImage.path=https://webtoon-test.s3.ap-northeast-2.amazonaws.com/default.jpg

--- a/src/test/java/com/project/webtoonzoa/service/UserServiceTest.java
+++ b/src/test/java/com/project/webtoonzoa/service/UserServiceTest.java
@@ -14,6 +14,7 @@ import com.project.webtoonzoa.entity.Enum.UserRoleEnum;
 import com.project.webtoonzoa.entity.User;
 import com.project.webtoonzoa.global.exception.PasswordNotConfirmException;
 import com.project.webtoonzoa.global.exception.PasswordNotEqualException;
+import com.project.webtoonzoa.repository.UserRecentPasswordRepository;
 import com.project.webtoonzoa.repository.UserRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +36,9 @@ class UserServiceTest {
 
     @Mock
     PasswordEncoder passwordEncoder;
+
+    @Mock
+    UserRecentPasswordRepository userRecentPasswordRepository;
 
     @InjectMocks
     UserService userService;

--- a/src/test/java/com/project/webtoonzoa/service/UserServiceTest.java
+++ b/src/test/java/com/project/webtoonzoa/service/UserServiceTest.java
@@ -26,10 +26,8 @@ import com.project.webtoonzoa.repository.RefreshTokenRepository;
 import com.project.webtoonzoa.repository.UserRecentPasswordRepository;
 import com.project.webtoonzoa.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
-import java.awt.Image;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -98,7 +96,7 @@ class UserServiceTest {
             //given
             given(userRepository.save(any(User.class))).willReturn(user);
             //when
-            Long id = userService.createUser(signUpRequestDto,multipartFile);
+            Long id = userService.createUser(signUpRequestDto, multipartFile);
             //then
             assertEquals(user.getId(), id, "id가 같지 않습니다.");
 
@@ -111,7 +109,7 @@ class UserServiceTest {
             given(userRepository.findByEmail(anyString())).willReturn(Optional.of(user));
             //when + then
             assertThrows(EmailExistenceException.class, () -> {
-                userService.createUser(signUpRequestDto,multipartFile);
+                userService.createUser(signUpRequestDto, multipartFile);
             });
         }
 
@@ -127,12 +125,13 @@ class UserServiceTest {
         User user1;
         User user2;
         List<User> users;
+
         @BeforeEach
         public void setUp() {
             adminUser = new User();
-            ReflectionTestUtils.setField(adminUser,"role",UserRoleEnum.ADMIN);
+            ReflectionTestUtils.setField(adminUser, "role", UserRoleEnum.ADMIN);
             user1 = new User();
-            ReflectionTestUtils.setField(user1,"role",UserRoleEnum.USER);
+            ReflectionTestUtils.setField(user1, "role", UserRoleEnum.USER);
             user2 = new User();
             users = new ArrayList<>();
             users.add(user1);


### PR DESCRIPTION
1. 최근 3번안에 사용한 비밀번호 사용불가
- recent password Table 추가
2. 회원차단기능 구현
3. 이메일 중복 예외 추가
4. 프로필 이미지 업로드 S3기능을 적용해서 구현
- admin token, default path, upload path => application properties에 추가
```
# aws s3 config
cloud.aws.region.static=ap-northeast-2
cloud.aws.stack.auto-=false

# aws s3 key
cloud.aws.s3.credentials.accessKey={accessKey}
cloud.aws.s3.credentials.secretKey={secretKey}
cloud.aws.s3.bucket={bucket-name}

# default image path
defaultImage.path=https://webtoon-test.s3.ap-northeast-2.amazonaws.com/default.jpg
```
- application properties에 s3 config설정 추가
5. Access token, refresh token 추가
- refresh는 클라이언트가 가지고 있는 것이 아닌 서버에 저장을 해서 access token이 만료될때마다 refresh를 체크해서 access token을 재발급
6. test 코드 service 메소드에 맞춰 추가